### PR TITLE
auto-updater overwrites updates it has already downloaded

### DIFF
--- a/modules/desktop/src/components/settings-menu/settings-menu.svelte
+++ b/modules/desktop/src/components/settings-menu/settings-menu.svelte
@@ -24,7 +24,6 @@
     class="group flex h-[28px] w-[28px] items-center justify-center rounded-sm border border-gray hover:bg-[#e1e1e1]"
     class:circle-badge={$updateStatus.status === "available" || $updateStatus.status === "ready"}
     on:click={() => (isOpen = !isOpen)}
-    class:animate-bounce={$updateStatus.status === "ready"}
     title="settings"
   >
     <div class="icon-gear text-l flex text-gray group-hover:text-black" />


### PR DESCRIPTION
If two auto updates occur simultaneously then the update file gets corrupted.  The electron auto-updater prevents simultaneous update checks BUT NOT simultaneous update downloads.  I'm going to open an issue with them.