### PR TITLE
add fallback to font family

### DIFF
--- a/modules/desktop/src/app.css
+++ b/modules/desktop/src/app.css
@@ -33,7 +33,7 @@ h4,
 h5,
 h6,
 .click-copy {
-  font-family: "mona-sans";
+  font-family: mona-sans, sans-serif;
 }
 
 .pk-version {

--- a/modules/desktop/src/components/package-banner/package-banner.svelte
+++ b/modules/desktop/src/components/package-banner/package-banner.svelte
@@ -65,7 +65,7 @@
     </figure>
     <article class="w-2/3 p-4 pt-8">
       <div class="align-center flex items-center gap-2">
-        <h3 class="font-mona text-3xl text-primary">{fixPackageName(pkg.name)}</h3>
+        <h3 class="text-3xl text-primary">{fixPackageName(pkg.name)}</h3>
         <ButtonIcon
           icon="pencil"
           helpText="edit package"


### PR DESCRIPTION
Font family didn't have a fallback so characters that mona-sans couldn't display were showing up wrong.