### PR TITLE
specify minimum macOS 11 support

### DIFF
--- a/modules/desktop/electron-builder.config.cjs
+++ b/modules/desktop/electron-builder.config.cjs
@@ -19,7 +19,8 @@ module.exports = {
     target: {
       target: "default",
       arch: ["x64", "arm64"]
-    }
+    },
+    minimumSystemVersion: "11"
   },
   afterSign: async (params) => {
     if (process.platform !== "darwin" || process.env.CSC_IDENTITY_AUTO_DISCOVERY === "false") {


### PR DESCRIPTION
resolves #556 

generated plist file includes:
```
<key>LSMinimumSystemVersion</key><string>11</string>
```