### PR TITLE
Do not error on fresh installs

### DIFF
--- a/modules/desktop/electron/libs/tea-dir.ts
+++ b/modules/desktop/electron/libs/tea-dir.ts
@@ -30,6 +30,12 @@ export const getGuiPath = () => {
 
 export async function getInstalledPackages(): Promise<InstalledPackage[]> {
   const pkgsPath = getTeaPath();
+
+  if (!fs.existsSync(pkgsPath)) {
+    log.info(`packages path ${pkgsPath} does not exist, no installed packages`);
+    return [];
+  }
+
   log.info("recursively reading:", pkgsPath);
   const folders = await deepReadDir({
     dir: pkgsPath,


### PR DESCRIPTION
Check if the tea dir exists before we try to find installed packages.  Sentry is showing errors for this, so let's handle it gracefully.