### PR TITLE
config e2e

### DIFF
--- a/modules/desktop/package.json
+++ b/modules/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tea",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": true,
   "description": "tea gui app",
   "author": "tea.xyz",

--- a/modules/desktop/wdio.conf.ts
+++ b/modules/desktop/wdio.conf.ts
@@ -20,7 +20,7 @@ export const config: Options.Testrunner = {
   exclude: [
     // 'path/to/excluded/files'
   ],
-  maxInstances: 10,
+  maxInstances: 1,
   capabilities: [
     {
       // capabilities for local browser web tests
@@ -32,7 +32,7 @@ export const config: Options.Testrunner = {
   baseUrl: "http://localhost",
   waitforTimeout: 10000,
   connectionRetryTimeout: 120000,
-  connectionRetryCount: 3,
+  connectionRetryCount: 5,
   services: [
     [
       "electron",
@@ -52,6 +52,8 @@ export const config: Options.Testrunner = {
   reporters: ["spec"],
   mochaOpts: {
     ui: "bdd",
-    timeout: 60000
-  }
+    timeout: 120000
+  },
+  specFileRetries: 3,
+  specFileRetriesDelay: 5
 };


### PR DESCRIPTION
set max instances to 1 so tests don't run in parallel (we need to configure a special .tea dir for each instance to run in parallel) and trying to remove some flakiness by changing timeouts and retries.