### PR TITLE
magic check

### DIFF
--- a/modules/desktop/electron/libs/cli.ts
+++ b/modules/desktop/electron/libs/cli.ts
@@ -136,3 +136,16 @@ export async function syncPantry() {
   await hooks.useSync();
   log.info("syncing pantry completed");
 }
+
+const envConfigPaths = [".bashrc", ".zshrc", ".zprofile", ".config/fish/config.fish", ".login"];
+
+export async function isMagicEnabled(): Promise<boolean> {
+  // 0. loop through envConfigPaths
+  // 1. check if TEA_MAGIC is set to prompt or 1
+  return false;
+}
+
+export async function enableMagic() {
+  // 0. detect if tea-cli is installed
+  // 1. spam all envConfigPaths with `export TEA_MAGIC=prompt`
+}

--- a/modules/desktop/electron/libs/cli.ts
+++ b/modules/desktop/electron/libs/cli.ts
@@ -142,10 +142,12 @@ const envConfigPaths = [".bashrc", ".zshrc", ".zprofile", ".config/fish/config.f
 export async function isMagicEnabled(): Promise<boolean> {
   // 0. loop through envConfigPaths
   // 1. check if TEA_MAGIC is set to prompt or 1
+  log.info("checking if magic is enabled....");
   return false;
 }
 
 export async function enableMagic() {
   // 0. detect if tea-cli is installed
   // 1. spam all envConfigPaths with `export TEA_MAGIC=prompt`
+  log.info("enabling magic....");
 }

--- a/modules/desktop/electron/libs/ipc.ts
+++ b/modules/desktop/electron/libs/ipc.ts
@@ -11,7 +11,13 @@ import { readSessionData, writeSessionData, pollAuth } from "./auth";
 import type { Packages, Session } from "../../src/libs/types";
 import log from "./logger";
 import { syncLogsAt } from "./v1-client";
-import { installPackage, openPackageEntrypointInTerminal, syncPantry } from "./cli";
+import {
+  enableMagic,
+  installPackage,
+  isMagicEnabled,
+  openPackageEntrypointInTerminal,
+  syncPantry
+} from "./cli";
 
 import { getAutoUpdateStatus, getUpdater, isDev } from "./auto-updater";
 
@@ -257,6 +263,18 @@ export default function initializeHandlers({ notifyMainWindow }: HandlerOptions)
     } catch (error) {
       log.error(error);
       return {};
+    }
+  });
+
+  ipcMain.handle("is-magic-enabled", async () => {
+    return isMagicEnabled();
+  });
+
+  ipcMain.handle("enable-magic", () => {
+    try {
+      enableMagic();
+    } catch (error) {
+      log.error(error);
     }
   });
 }

--- a/modules/desktop/src/libs/native-electron.ts
+++ b/modules/desktop/src/libs/native-electron.ts
@@ -306,3 +306,11 @@ export const getHeaders = async (path: string) => {
   const headers = await ipcRenderer.invoke("get-api-headers", path);
   return (headers || {}) as { [key: string]: string };
 };
+
+export const enableMagic = async () => {
+  await ipcRenderer.invoke("enable-magic");
+};
+
+export const isMagicEnabled = async (): Promise<boolean> => {
+  return await ipcRenderer.invoke("is-magic-enabled");
+};

--- a/modules/desktop/src/libs/native-mock.ts
+++ b/modules/desktop/src/libs/native-mock.ts
@@ -416,3 +416,11 @@ export const stopMonitoringTeaDir = async () => {
 };
 
 export const getHeaders = async (path: string) => ({});
+
+export const enableMagic = async () => {
+  console.log("enabled!");
+};
+
+export const isMagicEnabled = async () => {
+  return false;
+};

--- a/modules/desktop/src/libs/stores/notifications.ts
+++ b/modules/desktop/src/libs/stores/notifications.ts
@@ -50,6 +50,7 @@ export default function initNotificationStore() {
   };
 
   const init = () => {
+    // should this be here?
     isMagicEnabled().then((enabled) => {
       log.info("is magic enabled", enabled);
       if (!enabled) {

--- a/modules/desktop/test/specs/app.e2e.ts
+++ b/modules/desktop/test/specs/app.e2e.ts
@@ -11,7 +11,9 @@ describe("basic smoke test", () => {
     await utils.goHome();
   });
   it("checks if tea/xyz magic is enabled", async () => {
-    await utils.verifyAndCloseNotification(/^tea\/cli magic is not enabled. Click here to enable it./);
+    await utils.verifyAndCloseNotification(
+      /^tea\/cli magic is not enabled. Click here to enable it./
+    );
   });
 
   it("install brewkit from the made by tea tab", async () => {

--- a/modules/desktop/test/specs/app.e2e.ts
+++ b/modules/desktop/test/specs/app.e2e.ts
@@ -10,6 +10,9 @@ describe("basic smoke test", () => {
     utils = setupUtils(browser);
     await utils.goHome();
   });
+  it("checks if tea/xyz magic is enabled", async () => {
+    await utils.verifyAndCloseNotification(/^tea\/cli magic is not enabled. Click here to enable it./);
+  });
 
   it("install brewkit from the made by tea tab", async () => {
     const { screen } = utils!;


### PR DESCRIPTION
resolves #642

implementation:
1. initialize check if magic is enable from renderer(store): renderer->ipc->main->ipc->renderer
2. if not enabled create notification banner
3. on click enable from notification banner, spam all user env settings with env `export TEA_MAGIC=prompt`

this looks nasty, need additional ideas.