### PR TITLE
handle deleting packages that do not exist more gracefully

### DIFF
--- a/modules/desktop/electron/libs/tea-dir.ts
+++ b/modules/desktop/electron/libs/tea-dir.ts
@@ -153,9 +153,13 @@ export async function deletePackageFolder(fullName, version) {
   try {
     const foldPath = path.join(getTeaPath(), fullName, `v${version}`);
     log.info("rm:", foldPath);
-    await fs.rmSync(foldPath, { recursive: true });
+    fs.rmSync(foldPath, { recursive: true });
   } catch (error) {
-    log.error(error);
+    if (error.code === "ENOENT") {
+      log.info(`Attempted to delete non-existent folder: ${fullName} v${version}`);
+    } else {
+      log.error(error);
+    }
   }
 }
 

--- a/modules/desktop/src/libs/stores/pkgs.ts
+++ b/modules/desktop/src/libs/stores/pkgs.ts
@@ -243,8 +243,8 @@ const installPkg = async (pkg: GUIPackage, version?: string) => {
     await installPackage(pkg, versionToInstall);
     trackInstall(pkg.full_name);
 
-    // If the package was AVAILABLE previously then it was just installed, otherwise it was updated
-    const state = pkg.state === PackageStates.AVAILABLE ? "INSTALLED" : "UPDATED";
+    // If the package was NEEDS_UPDATE previously then it was updated, otherwise it was just installed
+    const state = pkg.state === PackageStates.NEEDS_UPDATE ? "UPDATED" : "INSTALLED";
     updatePackage(pkg.full_name, { displayState: { state, version: versionToInstall } });
 
     await refreshSinglePackage(pkg.full_name);
@@ -275,6 +275,7 @@ const uninstallPkg = async (pkg: GUIPackage) => {
       await deletePkg(pkg, v);
     }
 
+    resetPackageDisplayState(pkg);
     await refreshSinglePackage(pkg.full_name);
   } catch (error) {
     log.error(error);


### PR DESCRIPTION
Gracefully handle uninstalling a package with a folder that doesn't exist (instead of sending the error to sentry).  Also make sure to clear the `UPDATED` status correctly when the package is uninstalled.