### PR TITLE
use the pantry for display name and entry point

### DIFF
--- a/modules/desktop/electron/libs/cli.ts
+++ b/modules/desktop/electron/libs/cli.ts
@@ -1,5 +1,5 @@
 import { spawn } from "child_process";
-import { getGuiPath } from "./tea-dir";
+import { getGuiPath, getTeaPath } from "./tea-dir";
 import fs from "fs";
 import path from "path";
 import { hooks } from "@teaxyz/lib";
@@ -8,6 +8,8 @@ import log from "./logger";
 import { MainWindowNotifier } from "./types";
 import { Installation, porcelain } from "@teaxyz/lib";
 import type { Resolution } from "@teaxyz/lib/script/src/plumbing/resolve";
+import { GUIPackage } from "../../src/libs/types";
+import { getPantryDetails } from "./pantry";
 
 export async function installPackage(
   full_name: string,
@@ -51,23 +53,22 @@ async function installTeaCli() {
   return teaPkg.path.join("bin/tea");
 }
 
-export async function openPackageEntrypointInTerminal(pkg: string) {
+export async function openPackageEntrypointInTerminal(pkg: GUIPackage) {
   const cliBinPath = await installTeaCli();
-  log.info(`opening package ${pkg} with tea cli at ${cliBinPath}`);
 
-  let sh = `"${cliBinPath}" --sync --env=false +${pkg} `;
-  switch (pkg) {
-    case "github.com/AUTOMATIC1111/stable-diffusion-webui":
-      sh += `~/.tea/${pkg}/v*/entrypoint.sh`;
-      break;
-    case "cointop.sh":
-      sh += "cointop";
-      break;
-    default:
-      sh += "sh";
+  // look up the entrypoint for the package again in case it changed. This makes
+  // hacking on the entrypoint more ergonomic
+  const { entrypoint } = await getPantryDetails(pkg.full_name);
+
+  let sh = "sh";
+  if (entrypoint) {
+    sh = path.join(getTeaPath(), `${pkg.full_name}/v*`, entrypoint);
   }
 
-  const scriptPath = await createCommandScriptFile(sh);
+  const cmd = `"${cliBinPath}" --env=false +${pkg.full_name} "${sh}"`;
+  log.info(`opening package ${pkg.full_name} in terminal with command: ${cmd}`);
+
+  const scriptPath = await createCommandScriptFile(cmd);
 
   try {
     let stdout = "";

--- a/modules/desktop/electron/libs/ipc.ts
+++ b/modules/desktop/electron/libs/ipc.ts
@@ -8,7 +8,7 @@ import {
   stopMonitoringTeaDir
 } from "./tea-dir";
 import { readSessionData, writeSessionData, pollAuth } from "./auth";
-import type { Packages, Session } from "../../src/libs/types";
+import type { GUIPackage, Packages, Session } from "../../src/libs/types";
 import log from "./logger";
 import { syncLogsAt } from "./v1-client";
 import { installPackage, openPackageEntrypointInTerminal, syncPantry } from "./cli";
@@ -20,6 +20,7 @@ import { nanoid } from "nanoid";
 import { MainWindowNotifier } from "./types";
 import { unsubscribeToPackageTopic } from "./push-notification";
 import { getHeaders } from "./v1-client";
+import { getPantryDetails } from "./pantry";
 
 export type HandlerOptions = {
   // A function to call back to the current main
@@ -94,11 +95,11 @@ export default function initializeHandlers({ notifyMainWindow }: HandlerOptions)
   });
 
   ipcMain.handle("open-terminal", async (_, data) => {
-    const { pkg } = data as { pkg: string };
+    const { pkg } = data as { pkg: GUIPackage };
     try {
       // TODO: detect if mac or linux
       // current openTerminal is only design for Mac
-      log.info("open tea entrypoint in terminal for pkg:", pkg);
+      log.info("open tea entrypoint in terminal for pkg:", pkg.full_name);
       await openPackageEntrypointInTerminal(pkg);
     } catch (error) {
       log.error(error);
@@ -257,6 +258,14 @@ export default function initializeHandlers({ notifyMainWindow }: HandlerOptions)
     } catch (error) {
       log.error(error);
       return {};
+    }
+  });
+
+  ipcMain.handle("get-pantry-details", async (_event, full_name: string) => {
+    try {
+      return await getPantryDetails(full_name);
+    } catch (error) {
+      return error;
     }
   });
 }

--- a/modules/desktop/electron/libs/package.ts
+++ b/modules/desktop/electron/libs/package.ts
@@ -34,6 +34,12 @@ export async function loadPackageCache(): Promise<Packages> {
     if (pkgs?.packages) {
       // Remove any temporary properties that may have been added to the package (like installation progress)
       for (const [key, value] of Object.entries(pkgs.packages)) {
+        // Don't load local packages from the cache
+        if (value.is_local) {
+          delete pkgs.packages[key];
+          continue;
+        }
+
         const { install_progress_percentage, isUninstalling, synced, displayState, ...rest } =
           value;
         pkgs.packages[key] = rest as GUIPackage;

--- a/modules/desktop/electron/libs/pantry.ts
+++ b/modules/desktop/electron/libs/pantry.ts
@@ -1,0 +1,8 @@
+import { hooks } from "@teaxyz/lib";
+
+// Fetches the details for a package from the local pantry
+export async function getPantryDetails(full_name: string) {
+  const packageYml = await hooks.usePantry().project(full_name).yaml();
+  const { ["display-name"]: display_name, entrypoint, provides } = packageYml;
+  return { display_name, entrypoint, provides };
+}

--- a/modules/desktop/package.json
+++ b/modules/desktop/package.json
@@ -90,7 +90,7 @@
     "@sentry/electron": "^4.4.0",
     "@sentry/svelte": "^7.47.0",
     "@sentry/vite-plugin": "^0.7.2",
-    "@teaxyz/lib": "0.6.0",
+    "@teaxyz/lib": "0.6.2",
     "@types/electron": "^1.6.10",
     "@types/mousetrap": "^1.6.11",
     "@vitest/coverage-c8": "^0.27.1",

--- a/modules/desktop/src/components/buttons/open-package-button.svelte
+++ b/modules/desktop/src/components/buttons/open-package-button.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import type { GUIPackage } from "$libs/types";
+  import { openPackageEntrypointInTerminal } from "@native";
+  import Button from "@tea/ui/button/button.svelte";
+  import { t } from "$libs/translations";
+
+  export let pkg: GUIPackage;
+  export let buttonSize: "small" | "large" = "small";
+</script>
+
+<Button
+  class={buttonSize === "small" ? "h-8 text-xs" : "h-10"}
+  type="plain"
+  color="black"
+  onClick={(evt) => {
+    evt?.preventDefault();
+    openPackageEntrypointInTerminal(pkg);
+  }}
+>
+  {#if !!pkg.entrypoint}
+    {$t("package.open").toUpperCase()}
+  {:else}
+    {$t("package.open-in-terminal").toUpperCase()}
+  {/if}
+</Button>

--- a/modules/desktop/src/components/package-banner/package-banner.svelte
+++ b/modules/desktop/src/components/package-banner/package-banner.svelte
@@ -9,14 +9,15 @@
 
   import type { GUIPackage } from "$libs/types";
   import { packagesStore } from "$libs/stores";
-  import { openPackageEntrypointInTerminal, shellOpenExternal } from "@native";
+  import { shellOpenExternal } from "@native";
   import { findAvailableVersions, findRecentInstalledVersion } from "$libs/packages/pkg-utils";
   import { trimGithubSlug } from "$libs/github";
   import PackageImage from "../package-card/bg-image.svelte";
   import PackageVersionSelector from "$components/package-install-button/package-version-selector.svelte";
-  import { fixPackageName } from "$libs/packages/pkg-utils";
+  import { getPackageName } from "$libs/packages/pkg-utils";
   import { semverCompare } from "$libs/packages/pkg-utils";
   import InstallResultOverlay from "$components/install-result-overlay/install-result-overlay.svelte";
+  import OpenPackageButton from "$components/buttons/open-package-button.svelte";
 
   export let pkg: GUIPackage;
   let installing = false;
@@ -94,7 +95,7 @@
     <article class="w-2/3 p-4 pt-8">
       <div class="align-center flex items-center gap-2">
         <h3 data-testid="package-banner-header" class="text-3xl text-primary">
-          {fixPackageName(pkg.name)}
+          {getPackageName(pkg)}
         </h3>
         <ButtonIcon
           icon="pencil"
@@ -183,20 +184,7 @@
         {/if}
         {#if pkg.installed_versions?.length}
           <div class="min-w-[160px]">
-            <Button
-              class="h-10"
-              type="plain"
-              color="black"
-              onClick={() => {
-                openPackageEntrypointInTerminal(pkg.full_name);
-              }}
-            >
-              {#if pkg.full_name == "github.com/AUTOMATIC1111/stable-diffusion-webui"}
-                OPEN
-              {:else}
-                OPEN IN TERMINAL
-              {/if}
-            </Button>
+            <OpenPackageButton {pkg} buttonSize="large" />
           </div>
         {/if}
       </menu>

--- a/modules/desktop/src/components/package-card/local-package-card.svelte
+++ b/modules/desktop/src/components/package-card/local-package-card.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  import "../../app.css";
+  import type { GUIPackage } from "$libs/types";
+  import { t } from "$libs/translations";
+  import BgImage from "./bg-image.svelte";
+  import { getPackageName } from "$libs/packages/pkg-utils";
+  import OpenPackageButton from "$components/buttons/open-package-button.svelte";
+  import { toLower } from "lodash";
+
+  // Local packages are packages that are under development and are not yet published to the pantry
+  // They are currently so different from regular packages it's easier to have a separate component for them
+  export let pkg: GUIPackage;
+</script>
+
+<div class="relative">
+  <section
+    class="relative box-border h-[340px] w-full border border-gray bg-cover transition-all duration-300"
+  >
+    <BgImage class="absolute left-0 top-0 h-full w-full" {pkg} />
+
+    <div>
+      <div
+        data-testid={`package-card-${pkg.slug}`}
+        class="absolute h-full w-full flex-col justify-between"
+      >
+        <div
+          class="absolute left-3 top-3 flex h-5 items-center rounded-sm bg-white px-2 text-xs text-black"
+        >
+          {$t("package.local-package").toLowerCase()}
+        </div>
+        <div
+          class="content-container absolute bottom-0 left-0 flex h-1/2 w-full flex-col justify-center px-3.5 py-7"
+        >
+          <article class="w-full text-left">
+            <div class="flex items-center">
+              <h3 class="text-bold font-mona text-2xl font-bold text-white line-clamp-1">
+                {getPackageName(pkg)}
+              </h3>
+              <i class="icon-check-circle-o mb-1 ml-2 flex text-2xl text-[#e1e1e1]" />
+            </div>
+            <p class="h-[32px] text-xs font-thin lowercase line-clamp-2">
+              {pkg.short_description ?? ""}
+            </p>
+          </article>
+          <div class="mt-3.5 w-full">
+            <div class="flex w-fit flex-col items-center">
+              <div class="w-fit min-w-[160px]">
+                <OpenPackageButton {pkg} buttonSize="small" />
+              </div>
+              <div class="mt-1.5 h-[10px] leading-[10px]">
+                <span class="text-[10px]">{$t("package.not-in-pantry").toLowerCase()}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+
+<style>
+  .content-container {
+    background: linear-gradient(180deg, rgba(26, 26, 26, 0.3) 0%, rgba(26, 26, 26, 0.75) 72.92%);
+  }
+</style>

--- a/modules/desktop/src/components/package-card/package-card.svelte
+++ b/modules/desktop/src/components/package-card/package-card.svelte
@@ -6,7 +6,7 @@
   import BgImage from "./bg-image.svelte";
   import PackageInstallButton from "$components/package-install-button/package-install-button.svelte";
   import PackageInstalledBadge from "$components/package-install-button/package-installed-badge.svelte";
-  import { fixPackageName } from "$libs/packages/pkg-utils";
+  import { getPackageName } from "$libs/packages/pkg-utils";
   import InstallResultOverlay from "$components/install-result-overlay/install-result-overlay.svelte";
 
   export let pkg: GUIPackage;
@@ -51,7 +51,7 @@
             {#if layout === "bottom"}
               <div class="flex items-center">
                 <h3 class="text-bold font-mona text-2xl font-bold text-white line-clamp-1">
-                  {fixPackageName(pkg.name)}
+                  {getPackageName(pkg)}
                 </h3>
                 {#if pkg.state === PackageStates.INSTALLED}
                   <i class="icon-check-circle-o mb-1 ml-2 flex text-2xl text-[#00ffd0]" />
@@ -63,7 +63,7 @@
             {:else}
               <div class="mb-4 flex items-center">
                 <h3 class="text-bold font-mona text-3xl font-bold text-white line-clamp-1">
-                  {fixPackageName(pkg.name)}
+                  {getPackageName(pkg)}
                 </h3>
                 {#if pkg.state === PackageStates.INSTALLED}
                   <i class="icon-check-circle-o mb-1 ml-2 flex text-3xl text-[#00ffd0]" />

--- a/modules/desktop/src/components/packages/package.svelte
+++ b/modules/desktop/src/components/packages/package.svelte
@@ -4,25 +4,30 @@
   import { PackageStates, type GUIPackage } from "$libs/types";
   import { packagesStore } from "$libs/stores";
   import PackageCard from "$components/package-card/package-card.svelte";
+  import LocalPackageCard from "$components/package-card/local-package-card.svelte";
 
   export let tab = "all";
   export let pkg: GUIPackage;
   export let layout: "bottom" | "left" | "right" = "bottom";
 </script>
 
-<PackageCard
-  {pkg}
-  {layout}
-  link="/packages/{pkg.slug}?tab={tab}"
-  progessLoading={pkg.install_progress_percentage}
-  onClickCTA={async () => {
-    if (
-      [PackageStates.INSTALLED, PackageStates.INSTALLING, PackageStates.UPDATING].includes(
-        pkg.state
-      )
-    ) {
-      return;
-    }
-    packagesStore.installPkg(pkg);
-  }}
-/>
+{#if pkg.is_local}
+  <LocalPackageCard {pkg} />
+{:else}
+  <PackageCard
+    {pkg}
+    {layout}
+    link="/packages/{pkg.slug}?tab={tab}"
+    progessLoading={pkg.install_progress_percentage}
+    onClickCTA={async () => {
+      if (
+        [PackageStates.INSTALLED, PackageStates.INSTALLING, PackageStates.UPDATING].includes(
+          pkg.state
+        )
+      ) {
+        return;
+      }
+      packagesStore.installPkg(pkg);
+    }}
+  />
+{/if}

--- a/modules/desktop/src/components/packages/packages.svelte
+++ b/modules/desktop/src/components/packages/packages.svelte
@@ -13,6 +13,7 @@
   import { packagesStore, scrollStore } from "$libs/stores";
   import { afterUpdate, beforeUpdate } from "svelte";
   import { packageWasUpdated } from "$libs/packages/pkg-utils";
+  import SideMenu from "$components/side-menu/side-menu.svelte";
 
   const { packageList: allPackages } = packagesStore;
   export let packageFilter: SideMenuOptions = SideMenuOptions.all;
@@ -50,7 +51,8 @@
     [SideMenuOptions.new_packages]: (pkg: GUIPackage) => {
       return moment(pkg.created).isAfter(moment().subtract(30, "days"));
     },
-    [SideMenuOptions.made_by_tea]: (pkg: GUIPackage) => pkg.full_name.includes("tea.xyz")
+    [SideMenuOptions.made_by_tea]: (pkg: GUIPackage) => pkg.full_name.includes("tea.xyz"),
+    [SideMenuOptions.local]: (pkg: GUIPackage) => !!pkg.is_local
   };
 
   const onScroll = (e: Event) => {

--- a/modules/desktop/src/components/side-menu/side-menu.svelte
+++ b/modules/desktop/src/components/side-menu/side-menu.svelte
@@ -10,6 +10,7 @@
   export let activeOption: SideMenuOptions;
 
   $: needsUpdateCount = $packageList.filter((p) => p.state === PackageStates.NEEDS_UPDATE).length;
+  $: hasLocalPackages = $packageList.some((p) => p.is_local);
 </script>
 
 <aside id="side-menu" class="border border-b-0 border-l-0 border-t-0 border-gray p-2">
@@ -73,6 +74,14 @@
       active={activeOption === SideMenuOptions.made_by_tea}
       on:click={() => goto(`/?tab=${SideMenuOptions.made_by_tea}`)}
     />
+    {#if hasLocalPackages}
+      <MenuButton
+        label={$t("tags.local_packages").toLowerCase()}
+        icon="pencil"
+        active={activeOption === SideMenuOptions.local}
+        on:click={() => goto(`/?tab=${SideMenuOptions.local}`)}
+      />
+    {/if}
   </ul>
 </aside>
 

--- a/modules/desktop/src/libs/native-electron.ts
+++ b/modules/desktop/src/libs/native-electron.ts
@@ -167,7 +167,7 @@ export const updateSession = async (session: Partial<Session>) => {
   }
 };
 
-export const openPackageEntrypointInTerminal = (pkg: string) => {
+export const openPackageEntrypointInTerminal = (pkg: GUIPackage) => {
   try {
     ipcRenderer.invoke("open-terminal", { pkg });
   } catch (error) {
@@ -305,4 +305,12 @@ export const stopMonitoringTeaDir = async () => {
 export const getHeaders = async (path: string) => {
   const headers = await ipcRenderer.invoke("get-api-headers", path);
   return (headers || {}) as { [key: string]: string };
+};
+
+export const getPantryDetails = async (fullName: string) => {
+  const result = await ipcRenderer.invoke("get-pantry-details", fullName);
+  if (result instanceof Error) {
+    throw result;
+  }
+  return result;
 };

--- a/modules/desktop/src/libs/native-mock.ts
+++ b/modules/desktop/src/libs/native-mock.ts
@@ -423,3 +423,11 @@ export const stopMonitoringTeaDir = async () => {
 };
 
 export const getHeaders = async (path: string) => ({});
+
+export const getPantryDetails = async (fullName: string) => {
+  return {
+    display_name: "display-name",
+    entrypoint: "entrypoint.sh",
+    provides: ["bin/1", "bin/2"]
+  };
+};

--- a/modules/desktop/src/libs/packages/pkg-utils.ts
+++ b/modules/desktop/src/libs/packages/pkg-utils.ts
@@ -1,5 +1,5 @@
 import log from "$libs/logger";
-import type { GUIPackage } from "$libs/types";
+import { PackageStates, type GUIPackage } from "$libs/types";
 import SemVer from "@teaxyz/lib/semver";
 import { t } from "$libs/translations";
 
@@ -55,7 +55,9 @@ export const isInstalling = (pkg: GUIPackage) => {
   );
 };
 
-export const fixPackageName = (title: string) => {
+// Get the proper display name for a package and replace dashes with non-breaking dashes
+export const getPackageName = (pkg: GUIPackage) => {
+  const title = pkg.display_name || pkg.name;
   return title.replace("-", "\u2011");
 };
 
@@ -85,4 +87,38 @@ export const getPackageBadgeText = (pkg: GUIPackage) => {
   // UPDATED is a "pseudo-state" that overrides other states
   const state = packageWasUpdated(pkg) ? "UPDATED" : pkg.state;
   return t.get(`package.cta-${state}`);
+};
+
+export const newLocalPackage = (
+  full_name: string,
+  installed_versions: string[],
+  dev: boolean
+): GUIPackage => {
+  const prefix = `https://gui.tea.xyz/${dev ? "dev" : "prod"}/localplaceholder`;
+
+  return {
+    full_name: full_name,
+    name: full_name.split("/").pop() || "",
+    slug: full_name.replace(/[^\w\s]/gi, "_").toLocaleLowerCase(),
+    state: PackageStates.INSTALLED,
+    version: installed_versions[0],
+    installed_versions: installed_versions,
+    maintainer: "",
+    homepage: "",
+    created: new Date(),
+    last_modified: new Date(),
+    dl_count: 0,
+    installs: 0,
+    bottles: [],
+    categories: [],
+    manual_sorting: 0,
+    card_layout: "bottom",
+    keywords: [],
+    description: "",
+    short_description: "",
+    is_local: true,
+    image_512_url: `${prefix}/512x512.webp`,
+    image_128_url: `${prefix}/128x128.webp`,
+    image_added_at: new Date()
+  } as GUIPackage;
 };

--- a/modules/desktop/src/libs/stores/pkgs.ts
+++ b/modules/desktop/src/libs/stores/pkgs.ts
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import { derived, writable } from "svelte/store";
 import type { GUIPackage, InstalledPackage, Packages } from "../types";
 import { PackageStates } from "../types";
@@ -16,13 +17,19 @@ import {
   getInstalledVersionsForPackage,
   monitorTeaDir,
   stopMonitoringTeaDir,
-  isDev
+  isDev,
+  getPantryDetails
 } from "@native";
 
 import { getReadme, getContributors, getRepoAsPackage } from "$libs/github";
 import { NotificationType } from "@tea/ui/types";
 import { trackInstall, trackInstallFailed } from "$libs/analytics";
-import { addInstalledVersion, isInstalling, packageWasUpdated } from "$libs/packages/pkg-utils";
+import {
+  addInstalledVersion,
+  isInstalling,
+  newLocalPackage,
+  packageWasUpdated
+} from "$libs/packages/pkg-utils";
 import withDebounce from "$libs/utils/debounce";
 import { trimGithubSlug } from "$libs/github";
 import { notificationStore } from "$libs/stores";
@@ -58,6 +65,13 @@ const updateAllPackages = (guiPkgs: GUIPackage[]) => {
       pkgs.packages[pkg.full_name] = { ...oldPkg, ...pkg };
     });
     setBadgeCountFromPkgs(pkgs);
+    return pkgs;
+  });
+};
+
+const addPackage = (pkg: GUIPackage) => {
+  packageMap.update((pkgs) => {
+    pkgs.packages[pkg.full_name] = pkg;
     return pkgs;
   });
 };
@@ -191,17 +205,24 @@ const refreshPackages = async () => {
   // initialize Fuse index for fuzzy search
   indexPackages(guiPkgs);
 
+  // update installed package states and add any local packages to the list
+  const pkgMap = _.keyBy(guiPkgs, "full_name");
   try {
     const installedPkgs: InstalledPackage[] = await getInstalledPackages();
 
     log.info("updating state of packages");
-    for (const pkg of guiPkgs) {
-      const iPkg = installedPkgs.find((p) => p.full_name === pkg.full_name);
-      if (iPkg) {
+    for (const iPkg of installedPkgs) {
+      const pkg = pkgMap[iPkg.full_name];
+      if (pkg) {
         pkg.installed_versions = iPkg.installed_versions;
         updatePackage(pkg.full_name, {
           installed_versions: iPkg.installed_versions
         });
+      } else {
+        log.info(`Adding local package ${iPkg.full_name}`);
+        const localPkg = newLocalPackage(iPkg.full_name, iPkg.installed_versions, isDev);
+        pkgMap[localPkg.full_name] = localPkg;
+        addPackage(localPkg);
       }
     }
   } catch (error) {
@@ -212,6 +233,16 @@ const refreshPackages = async () => {
     await withRetry(syncPantry);
   } catch (err) {
     log.error(err);
+  }
+
+  // get pantry data for each package
+  for (const pkg of Object.values(pkgMap)) {
+    try {
+      const { display_name, provides, entrypoint } = await getPantryDetails(pkg.full_name);
+      updatePackage(pkg.full_name, { display_name, provides, entrypoint });
+    } catch (error) {
+      log.error(`failed to get pantry details for package: ${pkg.full_name}`, error);
+    }
   }
 
   refreshTimeoutId = setTimeout(() => refreshPackages(), packageRefreshInterval); // refresh every hour

--- a/modules/desktop/src/libs/translations/languages/de.json
+++ b/modules/desktop/src/libs/translations/languages/de.json
@@ -14,7 +14,11 @@
       "cta-UPDATING": "AKTUALISIEREN LÄUFT",
       "cta-UPDATED": "AKTUALISIERT",
       "cta-PRUNE": "REDUZIEREN",
-      "cta-PRUNING": "REDUZIEREN LÄUFT"
+      "cta-PRUNING": "REDUZIEREN LÄUFT",
+      "open": "Öffnen",
+      "open-in-terminal": "Im Terminal öffnen",
+      "local-package": "Lokales Paket",
+      "not-in-pantry": "Nicht in der Speisekammer"
     },
     "footer": {
       "quick-links-title": "Schnellzugriff",
@@ -64,7 +68,8 @@
       "featured": "Empfohlen",
       "essentials": "Grundlagen",
       "starstruck": "Starstruck Heavyweights",
-      "made_by_tea": "Hergestellt von tea"
+      "made_by_tea": "Hergestellt von tea",
+      "local_packages": "Lokale Pakete"
     },
     "tags": {
       "discover": "entdecken",
@@ -77,7 +82,8 @@
       "featured": "Empfohlen",
       "essentials": "Grundlagen",
       "starstruck": "Starstruck",
-      "made_by_tea": "Hergestellt von tea"
+      "made_by_tea": "Hergestellt von tea",
+      "local_packages": "Lokale Pakete"
     }
   }
 }

--- a/modules/desktop/src/libs/translations/languages/en.json
+++ b/modules/desktop/src/libs/translations/languages/en.json
@@ -14,7 +14,11 @@
       "cta-UPDATING": "UPDATING",
       "cta-UPDATED": "UPDATED",
       "cta-PRUNE": "PRUNE",
-      "cta-PRUNING": "PRUNING"
+      "cta-PRUNING": "PRUNING",
+      "open": "OPEN",
+      "open-in-terminal": "OPEN IN TERMINAL",
+      "local-package": "local package",
+      "not-in-pantry": "not yet added to pantry"
     },
     "footer": {
       "quick-links-title": "quick links",
@@ -64,7 +68,8 @@
       "featured": "Featured",
       "essentials": "Essentials",
       "starstruck": "Starstruck Heavyweights",
-      "made_by_tea": "made by tea"
+      "made_by_tea": "made by tea",
+      "local_packages": "Local Packages"
     },
     "tags": {
       "discover": "discover",
@@ -77,7 +82,8 @@
       "featured": "Featured",
       "essentials": "Essentials",
       "starstruck": "Starstruck",
-      "made_by_tea": "Made by tea"
+      "made_by_tea": "Made by tea",
+      "local_packages": "Local Packages"
     }
   }
 }

--- a/modules/desktop/src/libs/types.ts
+++ b/modules/desktop/src/libs/types.ts
@@ -39,6 +39,14 @@ export type GUIPackage = Package & {
   image_512_url?: string;
   image_128_url?: string;
   displayState?: PackageDisplayState | null;
+
+  // pantry properties
+  display_name?: string;
+  entrypoint?: string;
+  provides?: string[];
+
+  // a flag to indicate if the package is local and not from the pantry
+  is_local?: boolean;
 };
 
 export type Course = {
@@ -85,7 +93,8 @@ export enum SideMenuOptions {
   featured = "featured",
   essentials = "essentials",
   starstruck = "starstruck",
-  made_by_tea = "made_by_tea"
+  made_by_tea = "made_by_tea",
+  local = "local_packages"
 }
 
 export type InstalledPackage = Required<Pick<GUIPackage, "full_name" | "installed_versions">>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
       '@sveltejs/adapter-static': ^1.0.0-next.48
       '@sveltejs/kit': ^1.15.9
       '@tea/ui': workspace:*
-      '@teaxyz/lib': 0.6.0
+      '@teaxyz/lib': 0.6.2
       '@testing-library/jest-dom': ^5.16.5
       '@testing-library/svelte': ^3.2.2
       '@testing-library/webdriverio': ^3.2.1
@@ -116,7 +116,7 @@ importers:
       '@sentry/electron': 4.5.0
       '@sentry/svelte': 7.51.2_svelte@3.59.1
       '@sentry/vite-plugin': 0.7.2
-      '@teaxyz/lib': 0.6.0
+      '@teaxyz/lib': 0.6.2
       '@types/electron': 1.6.10
       '@types/mousetrap': 1.6.11
       '@vitest/coverage-c8': 0.27.3_jsdom@21.1.2
@@ -3640,15 +3640,15 @@ packages:
       tailwindcss: 3.3.2
     dev: false
 
-  /@teaxyz/lib/0.6.0:
-    resolution: {integrity: sha512-O9lYU/J1h+sbJApGcBUq4RlYymhfwB85k57hyaBhHq87DgXcR1xjhrKk0pfvn52sZT9jUoXH9UhPd1enWadXRQ==}
+  /@teaxyz/lib/0.6.2:
+    resolution: {integrity: sha512-5oeBydpbDBx1f13uHnxlilWPDog8hGC9xSIxyINvgKeEsCa6dAh6tzzuecRMRdZ7rdRFUIF8aruwpbcd+Him9A==}
     dependencies:
       '@deno/shim-crypto': 0.3.1
       '@deno/shim-deno': 0.16.1
-      is-what: 4.1.11
-      koffi: 2.3.20
+      is-what: 4.1.15
+      koffi: 2.4.2
       outdent: 0.8.0
-      undici: 5.22.0
+      undici: 5.22.1
     dev: false
 
   /@testing-library/dom/8.20.0:
@@ -8413,11 +8413,6 @@ packages:
       get-intrinsic: 1.2.0
     dev: true
 
-  /is-what/4.1.11:
-    resolution: {integrity: sha512-gr9+qDrJvdwT4+N2TAACsZQIB4Ow9j2eefqlh3m9JUV41M1LoKhcE+/j+IVni/r6U8Jnc1PwhjdjVJr+Xmtb0A==}
-    engines: {node: '>=12.13'}
-    dev: false
-
   /is-what/4.1.15:
     resolution: {integrity: sha512-uKua1wfy3Yt+YqsD6mTUEa2zSi3G1oPlqTflgaPJ7z63vUGN5pxFpnQfeSLMFnJDEsdvOtkp1rUWkYjB4YfhgA==}
     engines: {node: '>=12.13'}
@@ -8852,11 +8847,6 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
     dev: true
-
-  /koffi/2.3.20:
-    resolution: {integrity: sha512-y1W9JikdswM/CLmumtibnCknGJ6bmCNpWWD9G6WzP6Zj3lEY7d0J7jO82uMVoD1udz/2ZYUw2twhsGUGqeZH1g==}
-    requiresBuild: true
-    dev: false
 
   /koffi/2.4.2:
     resolution: {integrity: sha512-XDAev7zupyLwj9ze/4728T7NSHbnYXEptFrQuiEJS3ou8RJYp86HkXjqD9oNYoc4wWWAjeJtPJsRQfRVA/iqvg==}
@@ -12315,13 +12305,6 @@ packages:
 
   /underscore/1.13.6:
     resolution: {integrity: sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==}
-    dev: false
-
-  /undici/5.22.0:
-    resolution: {integrity: sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==}
-    engines: {node: '>=14.0'}
-    dependencies:
-      busboy: 1.6.0
     dev: false
 
   /undici/5.22.1:


### PR DESCRIPTION
This PR adds local packages to the GUI so that it's possible to test an entrypoint with a package that isn't in the pantry yet.  The package needs to be installed and the local pantry needs to be have a package.yml for the package.

We shouldn't release this until everyone is happy with the flow, but we need something so that we can start iterating.

I don't love how complex the package-card component is becoming, but maybe it will be simplified if we allow the user to go to the details page for a local package and always show open buttons to the user if a package is installed.  

https://www.loom.com/share/c396ba5e38ec42b1a49f30a0bdca80c4?sid=3f1ad17d-130c-4244-a9ab-530940cd49bf