### PR TITLE
embed terminal and webuis in app

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,17 @@ xc dev    # opens the app in dev mode
 
 # Internationalization / Translations
 
-We need help translating our user interface into different languages. The translation related source code are all in `./svelte/src/libs/translations/*`.
+We’d love your help in translating the gui into different languages.
+The translation related source code are all in `./svelte/src/libs/translations/*`.
 
 To add a new language:
 
-1. Create a json file in `./svelte/src/libs/translations/languages/[lang].json`. Copy the contents of `en.json` then translate.
-2. Import the new language in `./svelte/src/libs/translations/index.ts`. More instructions are in that file.
+1. Create a json file in `./svelte/src/libs/translations/languages/[lang].json`.
+   Copy the contents of `en.json` then translate.
+2. Import the new language in `./svelte/src/libs/translations/index.ts`.
+   More instructions are in that file.
+
+&nbsp;
 
 # Tasks
 
@@ -94,7 +99,7 @@ npm run package
 
 Builds only a `.app` that is not codesigned or notarized. Ideal for local testing.
 
-```
+```sh
 export CSC_IDENTITY_AUTO_DISCOVER=false
 export MAC_BUILD_TARGET=dir
 export NOTARIZE=false
@@ -105,7 +110,6 @@ npm run package
 ## Dev
 
 ```sh
-npm install
 npm run dev
 ```
 

--- a/electron/electron.ts
+++ b/electron/electron.ts
@@ -23,28 +23,30 @@ log.info("App starting...");
 if (app.isPackaged) {
   const dev = isDev();
 
-  Sentry.init({
-    environment: dev ? "development" : "production",
-    dsn: "https://5ff29bb5b3b64cd4bd4f4960ef1db2e3@o4504750197899264.ingest.sentry.io/4504750206746624",
-    debug: true,
-    release: app.getVersion(),
-    transportOptions: {
-      maxQueueAgeDays: 30,
-      maxQueueCount: 30,
-      beforeSend: async () => {
-        const ol = await net.isOnline();
-        return ol ? "send" : "queue";
+  if (!dev) {
+    Sentry.init({
+      environment: dev ? "development" : "production",
+      dsn: "https://5ff29bb5b3b64cd4bd4f4960ef1db2e3@o4504750197899264.ingest.sentry.io/4504750206746624",
+      debug: true,
+      release: app.getVersion(),
+      transportOptions: {
+        maxQueueAgeDays: 30,
+        maxQueueCount: 30,
+        beforeSend: async () => {
+          const ol = await net.isOnline();
+          return ol ? "send" : "queue";
+        }
       }
-    }
-  });
-  Sentry.configureScope(async (scope) => {
-    const session = await readSessionData();
-    scope.setUser({
-      id: session.device_id, // device_id this should exist in our pg db: developer_id is to many device_id
-      username: session?.user?.login || "" // github username or handler
     });
-  });
-  setSentryLogging(Sentry);
+    Sentry.configureScope(async (scope) => {
+      const session = await readSessionData();
+      scope.setUser({
+        id: session.device_id, // device_id this should exist in our pg db: developer_id is to many device_id
+        username: session?.user?.login || "" // github username or handler
+      });
+    });
+    setSentryLogging(Sentry);
+  }
 }
 
 init();

--- a/electron/libs/cli.ts
+++ b/electron/libs/cli.ts
@@ -1,15 +1,10 @@
-import { spawn } from "child_process";
-import { getGuiPath, getTeaPath } from "./tea-dir";
-import fs from "fs";
-import path from "path";
 import { hooks } from "@teaxyz/lib";
 
 import log from "./logger";
 import { MainWindowNotifier } from "./types";
-import { Installation, porcelain } from "@teaxyz/lib";
+import * as tea from "@teaxyz/lib";
+import { Installation } from "@teaxyz/lib";
 import type { Resolution } from "@teaxyz/lib/script/src/plumbing/resolve";
-import { GUIPackage } from "../../svelte/src/libs/types";
-import { getPantryDetails } from "./pantry";
 
 export async function installPackage(
   full_name: string,
@@ -20,7 +15,7 @@ export async function installPackage(
 
   const qualifedPackage = `${full_name}@${version}`;
   log.info(`installing package ${qualifedPackage}`);
-  const result = await porcelain.install(qualifedPackage, notifier);
+  const result = await tea.porcelain.install(qualifedPackage, notifier);
   log.info(`successfully installed ${qualifedPackage}`, result);
 }
 
@@ -47,78 +42,6 @@ function newInstallProgressNotifier(full_name: string, notifyMainWindow: MainWin
     }
   };
 }
-
-// the tea cli package is needed to open any other package in the terminal, so make sure it's installed and return the path
-async function installTeaCli() {
-  const installations = await porcelain.install("tea.xyz");
-  const teaPkg = installations.find((i) => i.pkg.project === "tea.xyz");
-  if (!teaPkg) {
-    throw new Error("could not find or install tea cli!");
-  }
-
-  return teaPkg.path.join("bin/tea");
-}
-
-export async function openPackageEntrypointInTerminal(pkg: GUIPackage) {
-  const cliBinPath = await installTeaCli();
-  // look up the entrypoint for the package again in case it changed. This makes
-  // hacking on the entrypoint more ergonomic
-  const { entrypoint } = await getPantryDetails(pkg.full_name);
-
-  let sh = "sh";
-  if (entrypoint) {
-    sh = path.join(getTeaPath(), `${pkg.full_name}/v*`, entrypoint);
-  }
-
-  const cmd = `"${cliBinPath}" --env=false +${pkg.full_name} "${sh}"`;
-  log.info(`opening package ${pkg.full_name} in terminal with command: ${cmd}`);
-
-  const scriptPath = await createCommandScriptFile(cmd);
-  try {
-    let stdout = "";
-    let stderr = "";
-
-    await new Promise((resolve, reject) => {
-      const child = spawn("/usr/bin/osascript", [scriptPath]);
-      child.stdout.on("data", (data) => {
-        stdout += data.toString().trim();
-      });
-      child.stderr.on("data", (data) => {
-        stderr += data.toString().trim();
-      });
-
-      child.on("exit", (code) => {
-        log.info("exit:", code, `\`${stdout}\``);
-        if (code == 0) {
-          resolve(stdout);
-        } else {
-          reject(new Error("failed to open terminal and run tea sh"));
-        }
-      });
-
-      child.on("error", () => {
-        reject(new Error(stderr));
-      });
-    });
-  } finally {
-    if (scriptPath) await fs.unlinkSync(scriptPath);
-  }
-}
-
-const createCommandScriptFile = async (cmd: string): Promise<string> => {
-  const guiFolder = getGuiPath();
-  const tmpFilePath = path.join(guiFolder, `${+new Date()}.scpt`);
-  const command = `${cmd.replace(/"/g, '\\"')}`;
-  const script = `
-    tell application "Terminal"
-      activate
-      do script "${command}"
-    end tell
-  `.trim();
-
-  await fs.writeFileSync(tmpFilePath, script, "utf-8");
-  return tmpFilePath;
-};
 
 export async function syncPantry() {
   log.info("syncing pantry");

--- a/electron/libs/entrypoints.ts
+++ b/electron/libs/entrypoints.ts
@@ -1,0 +1,139 @@
+import pty from "node-pty";
+
+import log from "./logger";
+import { MainWindowNotifier } from "./types";
+import * as tea from "@teaxyz/lib";
+import { GUIPackage } from "../../svelte/src/libs/types";
+import { getPantryDetails } from "./pantry";
+import { ipcMain } from "electron";
+
+// the tea cli package is needed to open any other package in the terminal, so make sure it's installed and return the path
+async function installTeaCli() {
+  const installations = await tea.porcelain.install("tea.xyz");
+  const install = installations.find((i) => i.pkg.project === "tea.xyz");
+  if (!install) {
+    throw new Error("installing tea/cli failed");
+  }
+  return install;
+}
+
+export interface Subprocess {
+  pty: pty.IPty;
+  output: string[];
+  guiURL?: string;
+}
+
+const ptys: Record<string, Subprocess> = {};
+
+// The main window must invoke this function to get the list of subprocesses and hydrate the store
+export function sendSubprocessesSnapshot(notifyMainWindow: MainWindowNotifier) {
+  const subprocesses: Record<
+    string,
+    { project: string; pid: number; output: string[]; guiURL?: string }
+  > = {};
+  Object.entries(ptys).forEach(([project, { pty, output, guiURL }]) => {
+    subprocesses[project] = { project, pid: pty.pid, output, guiURL };
+  });
+
+  notifyMainWindow("pty.out", { type: "snapshot", subprocesses });
+}
+
+export async function openPackageEntrypointInTerminal(
+  guipkg: GUIPackage,
+  notifyMainWindow: MainWindowNotifier
+) {
+  const cli = await installTeaCli();
+  const project = guipkg.full_name; //TODO make the naming in the API consistent with libtea and tea/cli thanks
+
+  if (project in ptys) {
+    log.info(`a process for project ${project} is already running`);
+    return;
+  }
+
+  log.info(`opening project ${project} in terminal using tea/cli at ${cli.path}`);
+
+  // look up the entrypoint for the package again in case it changed. This makes
+  // hacking on the entrypoint more ergonomic for local, third party developers
+  let { entrypoint } = await getPantryDetails(project);
+  entrypoint ??= `tea +${project} sh`;
+
+  notifyMainWindow("pty.out", { project, type: "reset" });
+
+  const installation = await tea.hooks
+    .useCellar()
+    .resolve({ project, constraint: new tea.semver.Range("*") });
+  const shell =
+    process.platform === "win32" ? "powershell.exe" : process.platform == "darwin" ? "zsh" : "bash";
+  const wet = await tea.plumbing.hydrate(installation.pkg);
+  const gas = await tea.plumbing.resolve(wet.pkgs);
+  if (gas.pending.length) throw new Error("pkg dependencies not installed");
+  const cwd = installation.path.string;
+
+  const installations = gas.installed;
+  if (!installations.some(({ pkg: { project } }) => project == "tea.xyz")) {
+    // dont’t dupe tea/cli if it’s already a dep
+    // ∵ useShellEnv is plumbing and thus will happily dupe env
+    installations.push(cli);
+  }
+
+  const rawenv = await tea.hooks.useShellEnv().map({ installations });
+  const env = tea.hooks.useShellEnv().flatten(rawenv);
+  env.PATH += ":/usr/bin:/bin";
+  env.TMPDIR ??= process.env.TMPDIR ?? "error";
+  env.HOME ??= process.env.HOME ?? "error";
+  env.TEA_GUI = "1";
+
+  /// user env is likely to screw up our env configuration
+  const args = ["--no-rcs"];
+
+  const ptyproc = pty.spawn(shell, args, {
+    name: "xterm-color", //NOTE just copied this from the docs so dunno if it’s a good choice or what
+    cwd, //TODO probs not a good CWD choice, probs make a new dir for each project in our tmpdir
+    env
+  });
+
+  ptyproc.onData((out) => {
+    ptys[project].output.push(out);
+
+    if (out.startsWith('{"xyz.tea":')) {
+      //FIXME bit flakey (this system)
+      const json = JSON.parse(out);
+      const url = json["xyz.tea"]?.["gui"];
+      if (url) {
+        ptys[project].guiURL = url;
+        notifyMainWindow("pty.out", { project, type: "enable-gui", guiURL: url });
+      }
+    }
+
+    notifyMainWindow("pty.out", {
+      project,
+      pid: ptyproc.pid,
+      out,
+      type: "out"
+    });
+  });
+
+  const inputListener = (event, { data, project: incoming_project }) => {
+    if (project === incoming_project) {
+      ptyproc.write(data);
+    }
+  };
+
+  ptyproc.onExit(({ exitCode }) => {
+    ipcMain.removeListener("pty.in", inputListener);
+    delete ptys[project];
+
+    notifyMainWindow("pty.out", {
+      pid: ptyproc.pid,
+      project,
+      out: `exited with ${exitCode}`,
+      type: "out"
+    });
+  });
+
+  ptyproc.write(`${entrypoint}\r`);
+
+  ipcMain.addListener("pty.in", inputListener);
+
+  ptys[project] = { pty: ptyproc, output: [] };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "mkdirp": "^2.1.3",
         "moment": "^2.29.4",
         "mousetrap": "^1.6.5",
+        "node-pty": "^1.0.0",
         "outdent": "^0.8.0",
         "prismjs": "^1.29.0",
         "pushy-electron": "^1.0.11",
@@ -59,6 +60,8 @@
         "undici": "^5.22.1",
         "upath": "^2.0.1",
         "vite-plugin-static-copy": "^0.13.1",
+        "xterm": "^5.2.1",
+        "xterm-addon-fit": "^0.7.0",
         "yaml": "^2.2.1"
       },
       "devDependencies": {
@@ -9089,6 +9092,11 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
+    },
     "node_modules/nanoid": {
       "version": "3.3.6",
       "funding": [
@@ -9213,6 +9221,15 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-pty": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.0.0.tgz",
+      "integrity": "sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "nan": "^2.17.0"
       }
     },
     "node_modules/node-releases": {
@@ -13176,6 +13193,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/xterm": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.2.1.tgz",
+      "integrity": "sha512-cs5Y1fFevgcdoh2hJROMVIWwoBHD80P1fIP79gopLHJIE4kTzzblanoivxTiQ4+92YM9IxS36H1q0MxIJXQBcA=="
+    },
+    "node_modules/xterm-addon-fit": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.7.0.tgz",
+      "integrity": "sha512-tQgHGoHqRTgeROPnvmtEJywLKoC/V9eNs4bLLz7iyJr1aW/QFzRwfd3MGiJ6odJd9xEfxcW36/xRU47JkD5NKQ==",
+      "peerDependencies": {
+        "xterm": "^5.0.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "mkdirp": "^2.1.3",
     "moment": "^2.29.4",
     "mousetrap": "^1.6.5",
+    "node-pty": "^1.0.0",
     "outdent": "^0.8.0",
     "prismjs": "^1.29.0",
     "pushy-electron": "^1.0.11",
@@ -138,6 +139,8 @@
     "undici": "^5.22.1",
     "upath": "^2.0.1",
     "vite-plugin-static-copy": "^0.13.1",
+    "xterm": "^5.2.1",
+    "xterm-addon-fit": "^0.7.0",
     "yaml": "^2.2.1"
   },
   "homepage": "https://tea.xyz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tea",
-  "version": "0.2.39",
+  "version": "0.2.40",
   "private": true,
   "description": "tea gui app",
   "author": "tea.xyz",

--- a/svelte/src/components/buttons/open-package-button.svelte
+++ b/svelte/src/components/buttons/open-package-button.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
+  import { createEventDispatcher } from "svelte";
   import type { GUIPackage } from "$libs/types";
   import { openPackageEntrypointInTerminal } from "@native";
   import Button from "$components/button/button.svelte";
   import { t } from "$libs/translations";
   export let pkg: GUIPackage;
   export let buttonSize: "small" | "large" = "small";
+
+  const dispatch = createEventDispatcher();
 </script>
 
 <Button
@@ -14,6 +17,7 @@
   onClick={(evt) => {
     evt?.preventDefault();
     openPackageEntrypointInTerminal(pkg);
+    dispatch("openterminal");
   }}
 >
   {#if !!pkg.entrypoint}

--- a/svelte/src/components/package-banner/package-banner.svelte
+++ b/svelte/src/components/package-banner/package-banner.svelte
@@ -186,7 +186,7 @@
         {/if}
         {#if pkg.installed_versions?.length}
           <div class="min-w-[160px]">
-            <OpenPackageButton {pkg} buttonSize="large" />
+            <OpenPackageButton on:openterminal {pkg} buttonSize="large" />
           </div>
         {/if}
       </menu>

--- a/svelte/src/components/tabs/tabs.svelte
+++ b/svelte/src/components/tabs/tabs.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import type { Tab } from "$libs/types";
+  import type { Tab, TabId } from "$libs/types";
   import { tabStore } from "$libs/stores";
   import Button from "../button/button.svelte";
+  import { t } from "$libs/translations";
 
   const { activeTab, setActiveTab } = tabStore;
 
@@ -9,7 +10,15 @@
   export { clazz as class };
   export let tabs: Tab[] = [];
 
-  $: activeTabId = $activeTab ?? tabs[0]?.id;
+  const getActiveTabId = (tabId: TabId, tabs: Tab[]) => {
+    if (!tabId || !tabs.filter(t => !t.hidden).map((t) => t.id).includes(tabId)) {
+      // If the tabId is not provided, invalid or the tab is hidden, use the first tab
+      return tabs[0]?.id;
+    }
+    return tabId;
+  }
+
+  $: activeTabId = getActiveTabId($activeTab, tabs);
 </script>
 
 <section class="relative h-auto {clazz}">

--- a/svelte/src/components/tabs/tabs.svelte
+++ b/svelte/src/components/tabs/tabs.svelte
@@ -1,50 +1,35 @@
 <script lang="ts">
   import type { Tab } from "$libs/types";
-  import { afterUpdate } from "svelte";
-
-  let clazz = "";
-
-  export { clazz as class };
-
+  import { tabStore } from "$libs/stores";
   import Button from "../button/button.svelte";
 
+  const { activeTab, setActiveTab } = tabStore;
+
+  let clazz = "";
+  export { clazz as class };
   export let tabs: Tab[] = [];
-  export let defaultTab: string;
 
-  let active: string;
-
-  let dirty = false;
-
-  afterUpdate(() => {
-    if (tabs.length && !active) {
-      if (!defaultTab) {
-        active = tabs[0].label;
-      } else if (!dirty) {
-        active = defaultTab;
-      }
-    }
-  });
+  $: activeTabId = $activeTab ?? tabs[0]?.id;
 </script>
 
 <section class="relative h-auto {clazz}">
   <menu class="flex gap-1">
     {#each tabs as tab}
-      <div class="border-gray text-white" class:border-b={tab.label === active}>
-        <Button
-          onClick={() => {
-            dirty = true;
-            active = tab.label;
-          }}
-        >
-          <span class:text-white={tab.label === active}>{tab.label}</span>
+      <div
+        class="border-gray text-white"
+        class:border-b={tab.id === activeTabId}
+        class:hidden={!!tab.hidden}
+      >
+        <Button onClick={() => setActiveTab(tab.id)}>
+          <span class:text-white={tab.id === activeTabId}>{tab.label}</span>
         </Button>
       </div>
     {/each}
   </menu>
 
   {#each tabs as tab}
-    {#if tab.label === active}
+    <div class:hidden={tab.id !== activeTabId}>
       <svelte:component this={tab.component} {...tab.props} />
-    {/if}
+    </div>
   {/each}
 </section>

--- a/svelte/src/components/tabs/tabs.svelte
+++ b/svelte/src/components/tabs/tabs.svelte
@@ -2,7 +2,6 @@
   import type { Tab, TabId } from "$libs/types";
   import { tabStore } from "$libs/stores";
   import Button from "../button/button.svelte";
-  import { t } from "$libs/translations";
 
   const { activeTab, setActiveTab } = tabStore;
 

--- a/svelte/src/components/tabs/tabs.svelte
+++ b/svelte/src/components/tabs/tabs.svelte
@@ -11,12 +11,18 @@
   export let tabs: Tab[] = [];
 
   const getActiveTabId = (tabId: TabId, tabs: Tab[]) => {
-    if (!tabId || !tabs.filter(t => !t.hidden).map((t) => t.id).includes(tabId)) {
+    if (
+      !tabId ||
+      !tabs
+        .filter((t) => !t.hidden)
+        .map((t) => t.id)
+        .includes(tabId)
+    ) {
       // If the tabId is not provided, invalid or the tab is hidden, use the first tab
       return tabs[0]?.id;
     }
     return tabId;
-  }
+  };
 
   $: activeTabId = getActiveTabId($activeTab, tabs);
 </script>

--- a/svelte/src/components/terminal/terminal.svelte
+++ b/svelte/src/components/terminal/terminal.svelte
@@ -39,6 +39,7 @@
       for (; index < ptyouts.output?.length; index++) {
         terminal.write(ptyouts.output[index]);
       }
+      fitAddon.fit();
     });
 
     const resizeObserver = new ResizeObserver((entries) => {

--- a/svelte/src/components/terminal/terminal.svelte
+++ b/svelte/src/components/terminal/terminal.svelte
@@ -15,6 +15,7 @@
   let pid = 0;
   let index = 0;
 
+  let terminalDiv: HTMLDivElement;
   let unsubscribe: (() => void) | null = null;
 
   onMount(() => {
@@ -39,6 +40,13 @@
         terminal.write(ptyouts.output[index]);
       }
     });
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      fitAddon.fit();
+    });
+    resizeObserver.observe(terminalDiv);
+
+    return () => resizeObserver.unobserve(terminalDiv);
   });
 
   onDestroy(() => {
@@ -48,6 +56,9 @@
   });
 </script>
 
-<div id="terminal" style="height: 80vh" />
-
-<!-- FIXME fix the above styling thank you -->
+<!-- This div has a very specific size of 571 pixels, the terminal component has breakpoints for showing a line 
+    and the spacing can get weird so this is as close to the breakpoint as possible with no left over space 
+    if some future traveler wants a different size, make sure to take these breakpoints into account -->
+<div class="border-gray mt-4 h-[571px] rounded-[5px] border p-1">
+  <div bind:this={terminalDiv} id="terminal" class="h-full w-full" />
+</div>

--- a/svelte/src/components/terminal/terminal.svelte
+++ b/svelte/src/components/terminal/terminal.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+  import { FitAddon } from "xterm-addon-fit";
+  import { ptys } from "$libs/stores";
+  import { Terminal } from "xterm";
+  import "xterm/css/xterm.css";
+  import "$appcss";
+  import { sendStdInToPty } from "$libs/native-electron";
+  import type { TeaSubprocess } from "$libs/stores/ptys";
+
+  export let project: string;
+
+  let terminal: Terminal;
+
+  let pid = 0;
+  let index = 0;
+
+  let unsubscribe: (() => void) | null = null;
+
+  onMount(() => {
+    terminal = new Terminal();
+    const fitAddon = new FitAddon();
+    terminal.loadAddon(fitAddon);
+    terminal.open(document.getElementById("terminal")!);
+    fitAddon.fit();
+
+    terminal.onKey((e) => {
+      sendStdInToPty({ project, data: e.key });
+    });
+
+    unsubscribe = ptys.subscribeToSubprocess(project, (ptyouts: TeaSubprocess) => {
+      if (pid != ptyouts.pid) {
+        terminal.reset();
+        pid = ptyouts.pid;
+        index = 0;
+      }
+
+      for (; index < ptyouts.output?.length; index++) {
+        terminal.write(ptyouts.output[index]);
+      }
+    });
+  });
+
+  onDestroy(() => {
+    unsubscribe?.();
+    terminal.dispose();
+    index = 0;
+  });
+</script>
+
+<div id="terminal" style="height: 80vh" />
+
+<!-- FIXME fix the above styling thank you -->

--- a/svelte/src/components/web-ui/web-ui.svelte
+++ b/svelte/src/components/web-ui/web-ui.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import type { TeaSubprocess } from "$libs/stores/ptys";
+  export let pty: TeaSubprocess | undefined;
+</script>
+
+{#if pty && pty.guiURL}
+  <iframe
+    id="terminal"
+    title="{pty.project} web UI"
+    src={pty.guiURL}
+    style="height: 100vh; width: 100%"
+  />
+{/if}
+
+<!--
+  ^^I cannot tell you why this styling is even needed
+  FIXME: you fix this thanks
+-->

--- a/svelte/src/components/web-ui/web-ui.svelte
+++ b/svelte/src/components/web-ui/web-ui.svelte
@@ -4,12 +4,14 @@
 </script>
 
 {#if pty && pty.guiURL}
-  <iframe
-    id="terminal"
-    title="{pty.project} web UI"
-    src={pty.guiURL}
-    style="height: 100vh; width: 100%"
-  />
+  <div class="border-gray mt-4 rounded-[5px] border p-1">
+    <iframe
+      id="terminal"
+      title="{pty.project} web UI"
+      src={pty.guiURL}
+      style="height: 100vh; width: 100%"
+    />
+  </div>
 {/if}
 
 <!--

--- a/svelte/src/libs/native-electron.ts
+++ b/svelte/src/libs/native-electron.ts
@@ -167,9 +167,25 @@ export const updateSession = async (session: Partial<Session>) => {
   }
 };
 
-export const openPackageEntrypointInTerminal = (pkg: GUIPackage) => {
+export const sendStdInToPty = async (opts: { data: string; project: string }) => {
   try {
-    ipcRenderer.invoke("open-terminal", { pkg });
+    await ipcRenderer.send("pty.in", opts);
+  } catch (error) {
+    log.error(error);
+  }
+};
+
+export const requestSubprocessesSnapshot = async () => {
+  try {
+    await ipcRenderer.invoke("request-subprocesses-snapshot");
+  } catch (error) {
+    log.error(error);
+  }
+};
+
+export const openPackageEntrypointInTerminal = async (pkg: GUIPackage) => {
+  try {
+    await ipcRenderer.invoke("open-terminal", { pkg });
   } catch (error) {
     log.error(error);
   }

--- a/svelte/src/libs/native-mock.ts
+++ b/svelte/src/libs/native-mock.ts
@@ -406,6 +406,10 @@ export const getAutoUpdateStatus = async (): Promise<AutoUpdateStatus> => {
   return { status: "up-to-date" };
 };
 
+export async function requestSubprocessesSnapshot() {
+  //noop
+}
+
 export async function openPackageEntrypointInTerminal(_pkg: GUIPackage) {
   //noop
 }

--- a/svelte/src/libs/stores.ts
+++ b/svelte/src/libs/stores.ts
@@ -12,9 +12,11 @@ import initNotificationStore from "./stores/notifications";
 import initAppUpdateStore from "./stores/update";
 import { trackSearch } from "./analytics";
 import initScrollStore from "./stores/scroll";
+import ptysStore from "./stores/ptys";
+import initTabStore from "./stores/tabs";
 
 export const featuredPackages = writable<Package[]>([]);
-
+export const ptys = ptysStore;
 export const packagesStore = pkgStore;
 
 export const initializeFeaturedPackages = async () => {
@@ -143,3 +145,5 @@ export const notificationStore = initNotificationStore();
 export const appUpdateStore = initAppUpdateStore();
 
 export const scrollStore = initScrollStore();
+
+export const tabStore = initTabStore();

--- a/svelte/src/libs/stores/ptys.ts
+++ b/svelte/src/libs/stores/ptys.ts
@@ -1,0 +1,80 @@
+import log from "$libs/logger";
+import { listenToChannel } from "@native";
+import { writable } from "svelte/store";
+
+const store = writable<Record<string, TeaSubprocess>>({});
+
+export interface TeaSubprocess {
+  project: string;
+  pid: number;
+  output: string[];
+  guiURL?: string;
+}
+
+interface SnapshotMessage {
+  type: "snapshot";
+  subprocesses: Record<string, TeaSubprocess>;
+}
+
+interface OutputMessage {
+  project: string;
+  type: "out";
+  pid: number;
+  out: string;
+}
+
+interface ResetMessage {
+  project: string;
+  type: "reset";
+}
+
+interface EnableGUIMessage {
+  project: string;
+  type: "enable-gui";
+  guiURL: string;
+}
+
+type Incoming = SnapshotMessage | OutputMessage | ResetMessage | EnableGUIMessage;
+
+listenToChannel("pty.out", (msg: Incoming) => {
+  if (msg.type === "snapshot") {
+    log.info("received new subprocess snapshot");
+    const { subprocesses } = msg;
+    store.update((_store) => {
+      return subprocesses;
+    });
+  } else if (msg.type === "out") {
+    const { project, pid, out } = msg;
+    store.update((store) => {
+      store[project] ??= { project, pid: pid ?? 0, output: [] };
+      store[project].output.push(out);
+      return store;
+    });
+  } else if (msg.type === "enable-gui") {
+    const { project, guiURL } = msg;
+    log.info(`enabling gui for project ${project} at ${guiURL}`);
+    store.update((store) => {
+      if (store[project]) {
+        store[project].guiURL = guiURL;
+      }
+      return store;
+    });
+  } else if (msg.type === "reset") {
+    const { project } = msg;
+    store.update((store) => {
+      delete store[project];
+      return store;
+    });
+  }
+});
+
+export default {
+  ptyStore: store,
+  subscribeToSubprocess: (project: string, callback: (process: TeaSubprocess) => void) => {
+    return store.subscribe((store) => {
+      if (store[project]) {
+        callback(store[project]);
+      }
+    });
+  }
+};

--- a/svelte/src/libs/stores/tabs.ts
+++ b/svelte/src/libs/stores/tabs.ts
@@ -1,0 +1,13 @@
+import type { TabId } from "$libs/types";
+import { writable } from "svelte/store";
+
+export default function initTabStore() {
+  const activeTab = writable<TabId>();
+
+  return {
+    activeTab,
+    setActiveTab: (id: TabId) => {
+      activeTab.set(id);
+    }
+  };
+}

--- a/svelte/src/libs/translations/languages/de.json
+++ b/svelte/src/libs/translations/languages/de.json
@@ -47,14 +47,18 @@
       "all": "Alle",
       "articles": "Artikel",
       "workshops": "Workshops",
-      "details": "Details",
-      "versions": "Versionen",
       "metadata": "Metadaten",
       "homepage": "Startseite",
       "documentation": "Dokumentation",
       "github-repository": "Github Repository",
       "contributors": "Mitwirkende",
       "view-on-github": "AUF GITHUB ANSEHEN"
+    },
+    "tabs": {
+      "details": "Details",
+      "versions": "Versionen",
+      "cli": "cli",
+      "gui": "gui"
     },
     "notification": {
       "update-header": "Tea/GUI auf {version} aktualisieren?",

--- a/svelte/src/libs/translations/languages/en.json
+++ b/svelte/src/libs/translations/languages/en.json
@@ -47,14 +47,18 @@
       "all": "All",
       "articles": "Articles",
       "workshops": "Workshops",
-      "details": "details",
-      "versions": "versions",
       "metadata": "Metadata",
       "homepage": "Homepage",
       "documentation": "Documentation",
       "github-repository": "Github Repository",
       "contributors": "Contributors",
       "view-on-github": "VIEW ON GITHUB"
+    },
+    "tabs": {
+      "details": "details",
+      "versions": "versions",
+      "cli": "cli",
+      "gui": "gui"
     },
     "notification": {
       "update-header": "update tea/gui to {version}?",

--- a/svelte/src/libs/translations/languages/ru.json
+++ b/svelte/src/libs/translations/languages/ru.json
@@ -47,14 +47,18 @@
       "all": "Все",
       "articles": "Статьи",
       "workshops": "Мастерские",
-      "details": "подробности",
-      "versions": "версии",
       "metadata": "Метаданные",
       "homepage": "Домашняя страница",
       "documentation": "Документация",
       "github-repository": "Репозиторий на Github",
       "contributors": "Участники",
       "view-on-github": "ПОСМОТРЕТЬ НА GITHUB"
+    },
+    "tabs": {
+      "details": "подробности",
+      "versions": "версии",
+      "cli": "cli",
+      "gui": "gui"
     },
     "notification": {
       "update-header": "обновить чай/графический интерфейс до версии {version}?",

--- a/svelte/src/libs/types.ts
+++ b/svelte/src/libs/types.ts
@@ -72,8 +72,12 @@ export type Bottle = {
   updated_at?: Date | string;
 };
 
+export type TabId = "details" | "versions" | "cli" | "gui";
+
 export type Tab = {
+  id: TabId;
   label: string;
+  hidden?: boolean;
   props?: {
     [key: string]:
       | string

--- a/svelte/src/routes/+layout.svelte
+++ b/svelte/src/routes/+layout.svelte
@@ -6,7 +6,7 @@
   import { afterNavigate } from "$app/navigation";
   import TopBar from "$components/top-bar/top-bar.svelte";
   import { navStore, packagesStore, searchStore } from "$libs/stores";
-  import { listenToChannel } from "@native";
+  import { requestSubprocessesSnapshot, listenToChannel } from "@native";
   import Mousetrap from "mousetrap";
 
   import SearchPopupResults from "$components/search-popup-results/search-popup-results.svelte";
@@ -54,6 +54,7 @@
       return false;
     });
     packagesStore.init();
+    await requestSubprocessesSnapshot();
     initSentry();
   });
 


### PR DESCRIPTION
# abstract

* uses node-pty to create a pseudo tty per project
* uses ipc to get that data to svelte
* if the app outputs JSON of the form `{xyz.tea: {gui: "URL"}}` we open the web ui iframe
    * agree this is not great, but it's enough for now

# caveats

* pty data is stored in a svelte store which means reloads lose pty output
* ui is not great
* terminal height doesn't resize to window
* ~needs to be able to send stdin back to the node-pty for interactivity to work~
* obv. having a gui tab on every pkg is not sensible
    * as well as the open button now having some ux conflict with the cli tab always being there
    * all this needs some UX/UI thought but this is a first stab
* web ui is unloaded when you change tab or leave the project page
    * this is no good ofc.

# for reviewers

* not yet ready for review
* happy to move code or do things differently. critique encouraged.

# notes

`full_name` needs to die, we carefully created terminology for our domain when building tea/cli. This terminology was already fully fleshed out before this project was created. It is not acceptable that all the work we did there was ignored and this project has its own completely different naming systems.