### PR TITLE
terminal should focus when made visible

### DIFF
--- a/svelte/src/components/terminal/terminal.svelte
+++ b/svelte/src/components/terminal/terminal.svelte
@@ -54,6 +54,7 @@
       // resize the terminal, but only after a delay allowing it to fully render or else the fitAddon will get the wrong size
       setTimeout(() => {
         fitAddon.fit();
+        terminal.focus();
       }, 10);
     });
     visibilityObserver.observe(terminalDiv);


### PR DESCRIPTION
Using the intersection/visibility observer to see when the terminal becomes visible and give it focus.  