### PR TITLE
handle package details page at small sizes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tea",
-  "version": "0.2.47",
+  "version": "0.2.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tea",
-      "version": "0.2.47",
+      "version": "0.2.48",
       "dependencies": {
         "@deno/shim-crypto": "^0.3.1",
         "@deno/shim-deno": "^0.16.1",

--- a/svelte/src/components/markdown/markdown.svelte
+++ b/svelte/src/components/markdown/markdown.svelte
@@ -47,7 +47,7 @@
 
 <section use:hook class="markdown-body flex w-full justify-stretch py-4">
   {#if source.type === "md" && source.data}
-    <div bind:this={markDownRoot}>
+    <div class="w-full" bind:this={markDownRoot}>
       <SvelteMarkdown source={tokenizeMarkdown(source.data)} {renderers} />
     </div>
   {:else if source.type === "rst" && html}

--- a/svelte/src/components/package-metas/package-metas.svelte
+++ b/svelte/src/components/package-metas/package-metas.svelte
@@ -113,7 +113,7 @@
   }
   ul > li {
     border-top: gray 1px solid;
-    height: 36px;
+    min-height: 36px;
     padding-top: 10px;
   }
 </style>

--- a/svelte/src/components/tool-tip/tool-tip.svelte
+++ b/svelte/src/components/tool-tip/tool-tip.svelte
@@ -5,7 +5,7 @@
 <div class="group relative">
   <slot name="target" />
   <div
-    class="tooltip border-gray invisible absolute left-1/2 top-full mt-4 w-full min-w-max translate-x-[-50%] border bg-black transition-all group-hover:visible"
+    class="tooltip border-gray invisible absolute left-1/2 top-full z-50 mt-4 w-full min-w-max translate-x-[-50%] border bg-black transition-all group-hover:visible"
   >
     <div class="px-6 py-2">
       <slot name="tooltip-content" />

--- a/svelte/src/routes/packages/[slug]/+page.svelte
+++ b/svelte/src/routes/packages/[slug]/+page.svelte
@@ -66,7 +66,7 @@
   <header
     class="text-gray flex h-[52px] items-center justify-between border border-x-0 border-t-0 px-16"
   >
-    <div>
+    <div class="overflow-hidden text-ellipsis whitespace-nowrap">
       <a class="hover:text-white hover:opacity-80" href="/">{$t("common.home")}</a>
       ›
       <a class="hover:text-white hover:opacity-80" href="/?tab={tab || 'discover'}"


### PR DESCRIPTION
update the styling so that the things don't break as bad when the details page gets small.

https://www.loom.com/share/e3e0da33593d49c4b2c4efc9640af438?sid=5a27765b-e3a0-4a85-9b2e-01a9161cfd81