### PR TITLE
change image loading

### DIFF
--- a/electron/libs/tea-dir.ts
+++ b/electron/libs/tea-dir.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import { app } from "electron";
 import log from "./logger";
-import type { InstalledPackage } from "../../svelte/src/libs/types";
+import { defaultImgUrl, type InstalledPackage } from "../../svelte/src/libs/types";
 import { mkdirp } from "mkdirp";
 import fetch from "node-fetch";
 import { SemVer, semver } from "@teaxyz/lib";
@@ -217,6 +217,7 @@ export async function cacheImage(url: string): Promise<string> {
       log.info("Image downloaded and cached:", imagePath);
     } catch (error) {
       log.error("Failed to download image:", error);
+      return defaultImgUrl;
     }
   } else {
     log.info("Image already cached:", imagePath);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tea",
-  "version": "0.2.48",
+  "version": "0.2.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tea",
-      "version": "0.2.48",
+      "version": "0.2.49",
       "dependencies": {
         "@deno/shim-crypto": "^0.3.1",
         "@deno/shim-deno": "^0.16.1",

--- a/svelte/src/components/package-banner/package-banner.svelte
+++ b/svelte/src/components/package-banner/package-banner.svelte
@@ -11,7 +11,7 @@
   import { packagesStore } from "$libs/stores";
   import { shellOpenExternal } from "@native";
   import { findAvailableVersions, findRecentInstalledVersion } from "$libs/packages/pkg-utils";
-  import PackageImage from "../package-card/bg-image.svelte";
+  import PlainPackageImage from "../package-card/plain-bg-image.svelte";
   import PackageVersionSelector from "$components/package-install-button/package-version-selector.svelte";
   import { getPackageName } from "$libs/packages/pkg-utils";
   import { semverCompare } from "$libs/packages/pkg-utils";
@@ -80,11 +80,12 @@
 <section class="mt-4 bg-black">
   <header class="flex">
     <figure class="grow-1 relative w-1/3">
-      <PackageImage
+      <PlainPackageImage
         class="min-h-[300px] w-full overflow-hidden"
-        {pkg}
-        layout="none"
-        plainImg={true}
+        project={pkg.full_name}
+        url={pkg.image_512_url}
+        cachedImageUrl={pkg.cached_image_url}
+        hasImage={!!pkg.image_added_at}
       />
       {#if pkg.install_progress_percentage && pkg.install_progress_percentage < 100}
         <div class="absolute left-0 top-0 z-40 h-full w-full bg-black bg-opacity-50">

--- a/svelte/src/components/package-card/bg-image.svelte
+++ b/svelte/src/components/package-card/bg-image.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { defaultImgUrl, type GUIPackage } from "$libs/types";
   import { loadPkgImage } from "./image-loader";
 
   let clazz = "";

--- a/svelte/src/components/package-card/image-loader.ts
+++ b/svelte/src/components/package-card/image-loader.ts
@@ -1,0 +1,23 @@
+import { packagesStore } from "$libs/stores";
+import { defaultImgUrl } from "$libs/types";
+
+export async function loadPkgImage(
+  project: string,
+  hasImage: boolean,
+  url?: string,
+  cachedImageUrl?: string
+) {
+  if (!url || !hasImage) {
+    return defaultImgUrl;
+  }
+
+  if (cachedImageUrl) {
+    // Don't wait for the image to cache, go ahead and return the url, this will cache the image in the background
+    // and force a re-render when the image is cached
+    packagesStore.cachePkgImage(project, url, cachedImageUrl);
+    return cachedImageUrl;
+  }
+
+  // If we don't have a cached image url, we need to grab the image and cache it
+  return await packagesStore.cachePkgImage(project, url, cachedImageUrl);
+}

--- a/svelte/src/components/package-card/local-package-card.svelte
+++ b/svelte/src/components/package-card/local-package-card.svelte
@@ -15,7 +15,13 @@
   <section
     class="border-gray relative box-border h-[340px] w-full border bg-cover transition-all duration-300"
   >
-    <BgImage class="absolute left-0 top-0 h-full w-full" {pkg} />
+    <BgImage
+      class="absolute left-0 top-0 h-full w-full"
+      project={pkg.full_name}
+      url={pkg.image_512_url}
+      cachedImageUrl={pkg.cached_image_url}
+      hasImage={!!pkg.image_added_at}
+    />
 
     <div>
       <div

--- a/svelte/src/components/package-card/package-card.svelte
+++ b/svelte/src/components/package-card/package-card.svelte
@@ -33,7 +33,14 @@
     class:active={isActive}
     class:updated={packageWasUpdated(pkg)}
   >
-    <BgImage class="absolute left-0 top-0 h-full w-full" {layout} {pkg} />
+    <BgImage
+      class="absolute left-0 top-0 h-full w-full"
+      {layout}
+      project={pkg.full_name}
+      url={pkg.image_512_url}
+      cachedImageUrl={pkg.cached_image_url}
+      hasImage={!!pkg.image_added_at}
+    />
 
     <a href={link} on:mousedown={activate} on:mouseup={deactivate} on:mouseleave={deactivate}>
       <div

--- a/svelte/src/components/package-card/plain-bg-image.svelte
+++ b/svelte/src/components/package-card/plain-bg-image.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { defaultImgUrl } from "$libs/types";
+  import { loadPkgImage } from "./image-loader";
+
+  export let clazz = "";
+  export { clazz as class };
+
+  // pass properties instead of the whole package object to avoid unnecessary re-rendering
+  export let project: string;
+  export let url: string | undefined;
+  export let cachedImageUrl: string | undefined;
+  export let hasImage: boolean;
+
+  $: promise = loadPkgImage(project, hasImage, url, cachedImageUrl);
+</script>
+
+{#await promise}
+  <img class={clazz} alt={project} src={defaultImgUrl} />
+{:then loadedImg}
+  <img class={clazz} alt={project} src={loadedImg} />
+{/await}

--- a/svelte/src/libs/stores/pkgs.ts
+++ b/svelte/src/libs/stores/pkgs.ts
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import { derived, writable } from "svelte/store";
 import type { GUIPackage, InstalledPackage, Packages } from "$libs/types";
-import { PackageStates, NotificationType } from "$libs/types";
+import { PackageStates, NotificationType, defaultImgUrl } from "$libs/types";
 import {
   getPackage,
   getDistPackages,
@@ -332,17 +332,12 @@ packageMap.subscribe(async (pkgs) => {
   writePackageCacheWithDebounce(pkgs);
 });
 
-const cachePkgImage = async (pkg: GUIPackage): Promise<string> => {
-  let cacheFileURL = "";
-  updatePackage(pkg.full_name, { cached_image_url: "" });
-  if (pkg.image_added_at && pkg.image_512_url) {
-    const result = await cacheImageURL(pkg.image_512_url);
-    if (result) {
-      cacheFileURL = result;
-      updatePackage(pkg.full_name, { cached_image_url: cacheFileURL });
-    }
+const cachePkgImage = async (project: string, url: string, cached_image_url?: string) => {
+  const result = await cacheImageURL(url);
+  if (result && result !== cached_image_url) {
+    updatePackage(project, { cached_image_url: result });
   }
-  return cacheFileURL;
+  return result || defaultImgUrl;
 };
 
 export const getPackageImageURL = async (

--- a/svelte/src/libs/types.ts
+++ b/svelte/src/libs/types.ts
@@ -215,3 +215,5 @@ export type AutoUpdateStatus = {
   status: "up-to-date" | "available" | "ready";
   version?: string;
 };
+
+export const defaultImgUrl = "/images/default-thumb.jpg";


### PR DESCRIPTION
Load images more in line with how the svelte docs say we should do this.  It greatly simplifies the overall code and removes the race that causes the wrong image to display for a package.

Closes #706 