### PR TITLE
Fix double click event handling in top bar

### DIFF
--- a/svelte/src/components/top-bar/top-bar.svelte
+++ b/svelte/src/components/top-bar/top-bar.svelte
@@ -20,7 +20,7 @@
 <header
   class="border-gray relative z-20 flex h-12 w-full items-center justify-between border border-x-0 border-t-0 pr-2"
   style="-webkit-app-region: drag"
-  on:dblclick={topbarDoubleClick}
+  on:dblclick|self={() => topbarDoubleClick()}
 >
   <ul class="text-gray flex h-10 items-center gap-1 pl-20 align-middle leading-10">
     <a href="/?tab=discover" data-testid="home-button">


### PR DESCRIPTION
Fixes: https://github.com/teaxyz/gui/issues/770

By using `self()` in the `on:dblclick` handler for the topbar, child elements are prevented from inheriting their parent element's event. 

https://github.com/teaxyz/gui/assets/8732757/7d90ae5b-b2c0-49b4-adc9-8854bf26209d

