### PR TITLE
Using cursor: pointer for package search result item

### DIFF
--- a/svelte/src/components/search-popup-results/package-search-result.svelte
+++ b/svelte/src/components/search-popup-results/package-search-result.svelte
@@ -54,4 +54,8 @@
     min-width: 140px;
     margin-right: 22px;
   }
+
+  header {
+    cursor: pointer;
+  }
 </style>


### PR DESCRIPTION
This provides indication that the search result item itself can be clicked to reveal the details page

<img width="982" alt="Screenshot 2023-08-16 at 1 18 47 PM" src="https://github.com/teaxyz/gui/assets/8732757/cdd0a1c3-0729-429c-8909-85812ffd1596">
