### PR TITLE
Adjust "Open in terminal" button size

### DIFF
--- a/svelte/src/components/package-card/package-card.svelte
+++ b/svelte/src/components/package-card/package-card.svelte
@@ -5,7 +5,6 @@
   import { findRecentInstalledVersion, packageWasUpdated } from "$libs/packages/pkg-utils";
   import BgImage from "./bg-image.svelte";
   import PackageInstallButton from "$components/package-install-button/package-install-button.svelte";
-  import PackageInstalledBadge from "$components/package-install-button/package-installed-badge.svelte";
   import { getPackageName } from "$libs/packages/pkg-utils";
   import InstallResultOverlay from "$components/install-result-overlay/install-result-overlay.svelte";
   import OpenPackageButton from "$components/buttons/open-package-button.svelte";
@@ -107,7 +106,7 @@
                       goto(link + "&detail_tab=cli");
                     }}
                     {pkg}
-                    buttonSize="large"
+                    buttonSize="small"
                   />
                 {:else}
                   <PackageInstallButton


### PR DESCRIPTION
When a package is installed, its card's "Open in Terminal" button is visibly larger/inconsistent with adjacent uninstalled package's "Install" buttons. This is remedied by using `buttonSize="small"` in the `<OpenPackageButton/>` component. An unused import for `PackageInstalledBadge` has also been removed.

**Before**
<img width="456" alt="Screenshot 2023-08-16 at 1 27 14 PM" src="https://github.com/teaxyz/gui/assets/8732757/02d8aeed-1f10-49b1-92f8-820bbd32b39c">

**After**
<img width="440" alt="Screenshot 2023-08-16 at 1 31 18 PM" src="https://github.com/teaxyz/gui/assets/8732757/5e30b785-cd3e-498c-8640-97e23e35d6ac">
