### PR TITLE
fix pkg banner image scaling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tea",
-  "version": "0.2.55",
+  "version": "0.2.56",
   "private": true,
   "description": "tea gui app",
   "author": "tea.xyz",

--- a/svelte/src/components/package-banner/package-banner.svelte
+++ b/svelte/src/components/package-banner/package-banner.svelte
@@ -81,7 +81,7 @@
   <header class="flex">
     <figure class="relative max-w-[240px]">
       <PlainPackageImage
-        class="min-h-[240px] w-full overflow-hidden rounded-lg"
+        class="overflow-hidden rounded-lg"
         project={pkg.full_name}
         url={pkg.image_512_url}
         cachedImageUrl={pkg.cached_image_url}


### PR DESCRIPTION
Package images were losing aspect ratio when the screen gets small.  They should maintain the ratio through all sizes.

Old behavior:
![Screenshot 2023-08-17 at 11 42 29 AM](https://github.com/teaxyz/gui/assets/1986070/4dcde9d2-dca6-4465-a50a-2bf474fff1b8)

New behavior:
![Screenshot 2023-08-17 at 11 41 11 AM](https://github.com/teaxyz/gui/assets/1986070/2493f58b-52c1-4def-a069-7ac2b8ce01a3)
