### PR TITLE
remove prod from cached image path

### DIFF
--- a/electron/libs/tea-dir.ts
+++ b/electron/libs/tea-dir.ts
@@ -194,7 +194,11 @@ async function downloadImage(url: string, imagePath: string): Promise<void> {
 
 export async function cacheImage(url: string): Promise<string> {
   const imageFolder = path.join(getGuiPath(), "cached_images");
-  const pkgFilePath = url.split("gui.tea.xyz")[1];
+  let pkgFilePath = url.split("gui.tea.xyz")[1];
+  //unfortunately we have prod in image url so strip it if it's present
+  if (pkgFilePath.startsWith("/prod")) {
+    pkgFilePath = pkgFilePath.replace("/prod", "");
+  }
   const imagePath = path.join(imageFolder, pkgFilePath);
   const fileName = path.basename(imagePath);
   const folderPath = imagePath.replace(fileName, "");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tea",
-  "version": "0.2.53",
+  "version": "0.2.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tea",
-      "version": "0.2.53",
+      "version": "0.2.56",
       "dependencies": {
         "@deno/shim-crypto": "^0.3.1",
         "@deno/shim-deno": "^0.16.1",


### PR DESCRIPTION
Prod images are stored at `~/.tea/tea.xyx/gui/cached_images/` and dev images are stored at `~/.tea/tea.xyx/gui/cached_images/dev/`.   There won't be a `/prod` folder any more.